### PR TITLE
fix: Code formatting in Utility.py cog & Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/cogs/Utility.py
+++ b/cogs/Utility.py
@@ -36,9 +36,12 @@ class Utility(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(description='translates text from one language into another.')
+    @commands.command(
+        description='translates text from one language into another.'
+    )
     @commands.cooldown(2, 20, commands.BucketType.member)
-    async def translate(self, ctx, source_lang: str, target_lang: str, *, text: str):
+    async def translate(self, ctx, source_lang: str, target_lang: str, *,
+                        text: str):
         await log(self.bot, 'translate', ctx)
 
         try:
@@ -67,7 +70,10 @@ class Utility(commands.Cog):
             embed_msg.set_footer(text='Powered by Google Translate')
             await ctx.send(embed=embed_msg)
 
-    @commands.command(description='DMs user a list of supported languages for the ,translate command.')
+    @commands.command(
+        description='DMs user a list of supported languages for the '
+                    ',translate command.'
+    )
     async def languages(self, ctx):
         embed_msg = discord.Embed(
             title="Supported Languages",
@@ -82,7 +88,8 @@ class Utility(commands.Cog):
 
     @commands.command(description='converts from one currency to another.')
     @commands.cooldown(2, 20, commands.BucketType.member)
-    async def convert(self, ctx, amount: float, source_cur: str, target_cur: str):
+    async def convert(self, ctx, amount: float, source_cur: str,
+                      target_cur: str):
         await log(self.bot, 'convert', ctx)
 
         source_cur = source_cur.upper()
@@ -117,7 +124,10 @@ class Utility(commands.Cog):
             )
             await ctx.send(embed=embed_msg)
 
-    @commands.command(description='DMs user a list of supported currencies for the ,convert command.')
+    @commands.command(
+        description='DMs user a list of supported currencies for the '
+                    ',convert command.'
+    )
     async def currencies(self, ctx):
         embed_msg = discord.Embed(
             title="Supported Currencies",
@@ -236,7 +246,8 @@ class Utility(commands.Cog):
                 if timeperiod > 119:
                     await asyncio.sleep(timeperiod - 60)
                     await ctx.send(
-                        f"{ctx.message.author.mention}, you have 60 seconds left!"
+                        f"{ctx.message.author.mention}, you have 60 seconds "
+                        "left!"
                     )
                     await asyncio.sleep(60)
                     await ctx.send(

--- a/cogs/Utility.py
+++ b/cogs/Utility.py
@@ -1,90 +1,175 @@
-from google_trans_new import google_translator
-from currency_converter import CurrencyConverter
-import discord
-from discord.ext import commands, tasks
-from discord.ext.commands.cooldowns import BucketType
-from datetime import datetime
 import asyncio
+import discord
+
+from currency_converter import CurrencyConverter
+from datetime import datetime
+from discord.ext import commands
+from discord.ext.commands.cooldowns import BucketType
+from google_trans_new import google_translator
+from google_trans_new import constant
+
 
 red = discord.Colour(0x1e807c)
 
+# Instantiate required objects
 translator = google_translator()
 c = CurrencyConverter()
 
+# Obtain dictionary containing all languages supported by google_trans_new
+supp_languages = constant.LANGUAGES
+
+
 async def log(bot, command, ctx):
     logs = bot.get_channel(769906608318316594)
-    embed_msg = discord.Embed(title=f"Command '{command}' used by {str(ctx.message.author)}.", description=f"**Text:**\n{ctx.message.content}\n\n**User ID:**\n{ctx.author.id}\n\n**Full Details:**\n{str(ctx.message)}", colour=red, timestamp=datetime.utcnow())
+    embed_msg = discord.Embed(
+        title=f"Command '{command}' used by {str(ctx.message.author)}.",
+        description=f"**Text:**\n{ctx.message.content}\n\n"
+                    f"**User ID:**\n{ctx.author.id}\n\n"
+                    f"**Full Details:**\n{str(ctx.message)}",
+        colour=red,
+        timestamp=datetime.utcnow()
+    )
     await logs.send(embed=embed_msg)
 
-class Utility(commands.Cog):
 
+class Utility(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command(description='translates text from one language into another.')
     @commands.cooldown(2, 20, commands.BucketType.member)
-    async def translate(self, ctx, source_language, destination_language, *, text):
+    async def translate(self, ctx, source_lang: str, target_lang: str, *, text: str):
         await log(self.bot, 'translate', ctx)
+
         try:
-            translation = translator.translate(text, lang_src=source_language, lang_tgt=destination_language)
-            embed_msg = discord.Embed(title="Translation Result", description=translation, colour=red,
-                                      timestamp=datetime.utcnow())
+            translation = translator.translate(
+                text,
+                lang_src=source_lang,
+                lang_tgt=target_lang
+            )
+            embed_msg = discord.Embed(
+                title="Translation Result",
+                description=translation,
+                colour=red,
+                timestamp=datetime.utcnow()
+            )
             embed_msg.set_footer(text='Powered by Google Translate')
             await ctx.send(embed=embed_msg)
         except ValueError:
-            embed_msg = discord.Embed(title="Invalid language!",
-                                      description="Please use `,languages` for a list of supported languages.\nCommand usage: `,translate (language 1) (language 2) (text)`",
-                                      colour=red,
-                                      timestamp=datetime.utcnow())
+            embed_msg = discord.Embed(
+                title="Invalid language!",
+                description="Please use `,languages` for a list of supported "
+                            "languages.\nCommand usage: `,translate "
+                            "(language 1) (language 2) (text)`",
+                colour=red,
+                timestamp=datetime.utcnow()
+            )
             embed_msg.set_footer(text='Powered by Google Translate')
             await ctx.send(embed=embed_msg)
-
 
     @commands.command(description='DMs user a list of supported languages for the ,translate command.')
     async def languages(self, ctx):
-        embed_msg = discord.Embed(title="Supported Languages",
-                                  description="af: afrikaans\nsq: albanian\nam: amharic\nar: arabic\nhy: armenian\naz: azerbaijani\neu: basque\nbe: belarusian\nbn: bengali\nbs: bosnian\nbg: bulgarian\nca: catalan\nceb: cebuano\nny: chichewa\nzh-cn: chinese (simplified)\nzh-tw: chinese (traditional)\nco: corsican\nhr: croatian\ncs: czech\nda: danish\nnl: dutch\nen: english\neo: esperanto\net: estonian\ntl: filipino\nfi: finnish\nfr: french\nfy: frisian\ngl: galician\nka: georgian\nde: german\nel: greek\ngu: gujarati\nht: haitian creole\nha: hausa\nhaw: hawaiian\niw: hebrew\nhi: hindi\nhmn: hmong\nhu: hungarian\nis: icelandic\nig: igbo\nid: indonesian\nga: irish\nit: italian\nja: japanese\njw: javanese\nkn: kannada\nkk: kazakh\nkm: khmer\nko: korean\nku: kurdish (kurmanji)\nky: kyrgyz\nlo: lao\nla: latin\nlv: latvian\nlt: lithuanian\nlb: luxembourgish\nmk: macedonian\nmg: malagasy\nms: malay\nml: malayalam\nmt: maltese\nmi: maori\nmr: marathi\nmn: mongolian\nmy: myanmar (burmese)\nne: nepali\nno: norwegian\nps: pashto\nfa: persian\npl: polish\npt: portuguese\npa: punjabi\nro: romanian\nru: russian\nsm: samoan\ngd: scots gaelic\nsr: serbian\nst: sesotho\nsn: shona\nsd: sindhi\nsi: sinhala\nsk: slovak\nsl: slovenian\nso: somali\nes: spanish\nsu: sundanese\nsw: swahili\nsv: swedish\ntg: tajik\nta: tamil\nte: telugu\nth: thai\ntr: turkish\nuk: ukrainian\nur: urdu\nuz: uzbek\nvi: vietnamese\ncy: welsh\nxh: xhosa\nyi: yiddish\nyo: yoruba\nzu: zulu\nfil: filipino\nhe: hebrew",
-                                  colour=red,
-                                  timestamp=datetime.utcnow())
+        embed_msg = discord.Embed(
+            title="Supported Languages",
+            description="\n".join(
+                "{}: {}".format(*p) for p in sorted(supp_languages.items())
+            ),
+            colour=red,
+            timestamp=datetime.utcnow()
+        )
         await ctx.author.send(embed=embed_msg)
         await ctx.message.add_reaction('📨')
 
-
     @commands.command(description='converts from one currency to another.')
     @commands.cooldown(2, 20, commands.BucketType.member)
-    async def convert(self, ctx, amount, source_curr, destination_curr):
+    async def convert(self, ctx, amount: float, source_cur: str, target_cur: str):
         await log(self.bot, 'convert', ctx)
+
+        source_cur = source_cur.upper()
+        target_cur = target_cur.upper()
+
         try:
-            conversion = c.convert(amount, source_curr.upper(), destination_curr.upper())
-            embed_msg = discord.Embed(title="Conversion Result",
-                                      description=f"**{amount}** {source_curr.upper()} is **{round(conversion, 2)}** {destination_curr.upper()}.",
-                                      colour=red, timestamp=datetime.utcnow())
+            conversion = c.convert(
+                amount,
+                source_cur,
+                target_cur
+            )
+            embed_msg = discord.Embed(
+                title="Conversion Result",
+                description="**{}** {} is **{:.2f}** {}.".format(
+                    amount,
+                    source_cur,
+                    conversion,  # :.2f sets the precision to 2 decimal places
+                    target_cur
+                ),
+                colour=red,
+                timestamp=datetime.utcnow()
+            )
             await ctx.send(embed=embed_msg)
         except ValueError:
-            embed_msg = discord.Embed(title="Invalid currency or number!",
-                                      description="Please use `,currencies` for a list of supported currencies.\nCommand usage: `,convert (amount) (currency 1) (currency 2)`",
-                                      colour=red,
-                                      timestamp=datetime.utcnow())
+            embed_msg = discord.Embed(
+                title="Invalid currency or number!",
+                description="Please use `,currencies` for a list of supported "
+                            "currencies.\nCommand usage: `,convert (amount) "
+                            "(currency 1) (currency 2)`",
+                colour=red,
+                timestamp=datetime.utcnow()
+            )
             await ctx.send(embed=embed_msg)
-
 
     @commands.command(description='DMs user a list of supported currencies for the ,convert command.')
     async def currencies(self, ctx):
-        embed_msg = discord.Embed(title="Supported Currencies",
-                                  description="AUD Australian dollar\nBGN Bulgarian lev\nBRL Brazilian real\nCAD Canadian dollar\nCHF Swiss franc\nCNY Chinese yuan renminbi\nCZK Czech koruna\nDKK Danish krone\nGBP Pound sterling\nHKD Hong Kong dollar\nHRK Croatian kuna\nHUF Hungarian forint\nIDR Indonesian rupiah\nILS Israeli shekel\nINR Indian rupee\nISK Icelandic krona\nJPY Japanese yen\nKRW South Korean won\nMXN Mexican peso\nMYR Malaysian ringgit\nNOK Norwegian krone\nNZD New Zealand dollar\nPHP Philippine peso\nPLN Polish zloty\nRON Romanian leu\nRUB Russian rouble\nSEK Swedish krona\nSGD Singapore dollar\nTHB Thai baht\nTRY Turkish lira\nUSD US dollar\nZAR South African rand",
-                                  colour=red,
-                                  timestamp=datetime.utcnow())
+        embed_msg = discord.Embed(
+            title="Supported Currencies",
+            description="AUD Australian dollar\n"
+                        "BGN Bulgarian lev\n"
+                        "BRL Brazilian real\n"
+                        "CAD Canadian dollar\n"
+                        "CHF Swiss franc\n"
+                        "CNY Chinese yuan renminbi\n"
+                        "CZK Czech koruna\n"
+                        "DKK Danish krone\n"
+                        "GBP Pound sterling\n"
+                        "HKD Hong Kong dollar\n"
+                        "HRK Croatian kuna\n"
+                        "HUF Hungarian forint\n"
+                        "IDR Indonesian rupiah\n"
+                        "ILS Israeli shekel\n"
+                        "INR Indian rupee\n"
+                        "ISK Icelandic krona\n"
+                        "JPY Japanese yen\n"
+                        "KRW South Korean won\n"
+                        "MXN Mexican peso\n"
+                        "MYR Malaysian ringgit\n"
+                        "NOK Norwegian krone\n"
+                        "NZD New Zealand dollar\n"
+                        "PHP Philippine peso\n"
+                        "PLN Polish zloty\n"
+                        "RON Romanian leu\n"
+                        "RUB Russian rouble\n"
+                        "SEK Swedish krona\n"
+                        "SGD Singapore dollar\n"
+                        "THB Thai baht\n"
+                        "TRY Turkish lira\n"
+                        "USD US dollar\n"
+                        "ZAR South African rand",
+            colour=red,
+            timestamp=datetime.utcnow()
+        )
         await ctx.author.send(embed=embed_msg)
         await ctx.message.add_reaction('📨')
 
     @commands.command()
-    async def timer(self, ctx, time):
-        symbols = {'s': 1,
-                   'm': 60,
-                   'h': 3600,
-                   'd': 86400}
+    async def timer(self, ctx, time: str):
+        symbols = {
+            's': 1,
+            'm': 60,
+            'h': 3600,
+            'd': 86400
+        }
         worked = False
         failed = False
+
         try:
             for symbol in symbols:
                 if symbol in time:
@@ -92,10 +177,20 @@ class Utility(commands.Cog):
                     timeperiod = int(time.replace(symbol, '')) * conversion
                     worked = True
         except ValueError:
-            embed_msg = discord.Embed(title=f"'{time}' is an invalid time period!",
-                                      description='Please only use whole numbers, and the following symbols:\n```s: seconds\nm: minutes\nh: hours\nd: days```\nExample: `,timer 10m`', colour=red)
+            embed_msg = discord.Embed(
+                title=f"'{time}' is an invalid time period!",
+                description="Please only use whole numbers, and the following "
+                            "symbols:\n"
+                            "```s: seconds\n"
+                            "m: minutes\n"
+                            "h: hours\n"
+                            "d: days```\n"
+                            "Example: `,timer 10m`",
+                colour=red
+            )
             await ctx.send(embed=embed_msg)
             failed = True
+
         if worked is True:
             if not timeperiod > 1209600:
                 if timeperiod > 59:
@@ -106,6 +201,7 @@ class Utility(commands.Cog):
                         strtime = f"{strtime} minute"
                     else:
                         strtime = f"{strtime} minutes"
+
                 if timeperiod > 3599:
                     strtime = str(round(timeperiod / 3600, 1))
                     if strtime.endswith('.0'):
@@ -114,6 +210,7 @@ class Utility(commands.Cog):
                         strtime = f"{strtime} hour"
                     else:
                         strtime = f"{strtime} hours"
+
                 if timeperiod > 86399:
                     strtime = str(round(timeperiod / 86400, 1))
                     if strtime.endswith('.0'):
@@ -122,27 +219,54 @@ class Utility(commands.Cog):
                         strtime = f"{strtime} day"
                     else:
                         strtime = f"{strtime} days"
+
                 if timeperiod < 60:
                     if timeperiod == 1:
                         strtime = f"{timeperiod} second"
                     else:
                         strtime = f"{timeperiod} seconds"
-                await ctx.send(embed=discord.Embed(title="Timer Started", description=strtime, colour=red))
+
+                embed_msg = discord.Embed(
+                    title="Timer Started",
+                    description=strtime,
+                    colour=red
+                )
+                await ctx.send(embed=embed_msg)
+
                 if timeperiod > 119:
                     await asyncio.sleep(timeperiod - 60)
-                    await ctx.send(f"{ctx.message.author.mention}, you have 60 seconds left!")
+                    await ctx.send(
+                        f"{ctx.message.author.mention}, you have 60 seconds left!"
+                    )
                     await asyncio.sleep(60)
-                    await ctx.send(f"{ctx.message.author.mention}, your timer is up!")
+                    await ctx.send(
+                        f"{ctx.message.author.mention}, your timer is up!"
+                    )
                 else:
                     await asyncio.sleep(timeperiod)
-                    await ctx.send(f"{ctx.message.author.mention}, your timer is up!")
+                    await ctx.send(
+                        f"{ctx.message.author.mention}, your timer is up!"
+                    )
             else:
-                embed_msg = discord.Embed(title=f"The maximum amount of time for a timer is 2 weeks!", colour=red)
+                embed_msg = discord.Embed(
+                    title="The maximum amount of time for a timer is 2 weeks!",
+                    colour=red
+                )
                 await ctx.send(embed=embed_msg)
         elif failed is False:
-            embed_msg = discord.Embed(title=f"'{time}' is an invalid time period!",
-                                      description='Please only use whole numbers, and the following symbols:\n```s: seconds\nm: minutes\nh: hours\nd: days```\nExample: `,startgiveaway 10d nitro`', colour=red)
+            embed_msg = discord.Embed(
+                title=f"'{time}' is an invalid time period!",
+                description="Please only use whole numbers, and the following "
+                            "symbols:\n"
+                            "```s: seconds\n"
+                            "m: minutes\n"
+                            "h: hours\n"
+                            "d: days```\n"
+                            "Example: `,startgiveaway 10d nitro`",
+                colour=red
+            )
             await ctx.send(embed=embed_msg)
+
 
 def setup(bot):
     bot.add_cog(Utility(bot))


### PR DESCRIPTION
This PR addresses some serious formatting issues - code that either visually looked chaotic or that violated the [PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/). Despite most of the other cogs/files having similar issues, I decided to keep this PR small and focus only on the `Utility.py` cog.

Non-comprehensive list of inconsistencies/issues that I observed:
* Using more than one blank line to separate functions (within a class)
* No regard for PEP 8 [Maximum Line Length](https://www.python.org/dev/peps/pep-0008/#maximum-line-length) (which aside from being an industry standard, also makes your life easier when viewing files in a text editor or IDE)
* Less than ideal usage of indentation to separate functions/objects across multiple lines
*  No newline at end of file
* Unused imports

---

In regard to max line length, I also sought out ways to keep the following two lines as short/small as possible.

https://github.com/QuaKe8782/PartsBot/blob/0c7d271410cc51efa0b8eda30fda57e24514582d/cogs/Utility.py#L46

https://github.com/QuaKe8782/PartsBot/blob/0c7d271410cc51efa0b8eda30fda57e24514582d/cogs/Utility.py#L74


For Line 46 (which is part of the `,languages` command), I couldn't help but notice that the module currently being used to facilitate translations ([google_trans_new](https://github.com/lushan88a/google_trans_new)) **already has a variable constant** that contains a dictionary populated with all the supported languages.

My proposed implementation can be seen below - take special note of the (technically) one-liner that iterates through the dictionary, formats the key:value pairs as a string (ex. fr: french) and outputs each pair on a newline. Running the `,languages` command with this cleaner implementation will output a practically identical list of languages to the current one (with an added bonus that the languages will now be in alphabetical order as well).

```py
from google_trans_new import constant
...
# Obtain dictionary containing all languages supported by google_trans_new
supp_languages = constant.LANGUAGES
...
discord.Embed(
     title=...
     description="\n".join(
         "{}: {}".format(*p) for p in sorted(supp_languages.items())
         ),
     colour=...
)
```

For Line 74 (part of the `,currencies` command), I couldn't find anything similar in the CurrencyConverter module, so for the interim I simply separated each currency on a newline (for readability).

---

Lastly, I've added a `.gitignore` file, which if you weren't aware is a file that tells **git** to stop tracking certain files/folders that you wouldn't want to commit (intentionally or accidentally) to your repository (e.g. virtual environment, \_\_pycache__).